### PR TITLE
Added italics

### DIFF
--- a/Themes/Quiet Light.css
+++ b/Themes/Quiet Light.css
@@ -65,6 +65,7 @@ meta.gutter.selected {
 
 keyword {
     color: #4b83cd;
+    font-style: italic;
 }
 comment {
     color: #aaa;
@@ -119,10 +120,12 @@ identifier.variable,
 identifier.core.keyword,
 identifier.argument {
     color: #7a3e9d;
+    font-style: italic;
 }
 identifier.property {}
 identifier.decorator {
     color: #aaa;
+    font-style: italic;
 }
 identifier.function,
 identifier.method {


### PR DESCRIPTION
Italics were added to the `keyword`, `identifier.argument`, and `identifier.decorator` definitions to more make them more visually pronounced.  This becomes even more striking when using a font that treats italics as cursive (Operator, Dank Mono, etc.)